### PR TITLE
Add fissile path for Vagrant

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,6 +8,7 @@ fi
 if type -t PATH_add >/dev/null ; then
     # PATH modification is optional; ignore if we're not using direnv
     PATH_add ../fissile/build/linux-amd64/
+    PATH_add ../hcf/output/bin/
 fi
 
 export FISSILE_RELEASE=${PWD}/src/uaa-release,${PWD}/src/cf-mysql-release,${PWD}/src/hcf-release


### PR DESCRIPTION
Allows this repo to build when run from the Vagrant box, which expects it to be checked out at the same level as the `hcf` repo.