### PR TITLE
Make direnv optional

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,20 +1,42 @@
-# vim: set filetype=sh :
+#!/usr/bin/env bash
+# This file is both used via direnv, as well as by directly sourcing it in a
+# shell (when being run from CI).
 
-if type -t source_up >/dev/null ; then
-    # Only needed under direnv
-    source_up
+if type source_up >/dev/null 2>/dev/null; then
+    # Using direnv; load any higher up .envrc
+    source_up || true
+else
+    PWD="$(cd "$(dirname "${BASH_SOURCE[0]:-${KSH_VERSION:+${.sh.file}}${KSH_VERSION:-$0}}")" && pwd)"
 fi
 
-if type -t PATH_add >/dev/null ; then
-    # PATH modification is optional; ignore if we're not using direnv
-    PATH_add ../fissile/build/linux-amd64/
-    PATH_add ../hcf/output/bin/
+if test -d ../hcf/output/bin/ ; then
+    PATH="$(cd ../hcf/output/bin/ && pwd)${PATH:+:${PATH}}"
+fi
+if test -d ../fissile/build/linux-amd64/ ; then
+    PATH="$(cd ../fissile/build/linux-amd64/ && pwd)${PATH:+:${PATH}}"
 fi
 
-export FISSILE_RELEASE=${PWD}/src/uaa-release,${PWD}/src/cf-mysql-release,${PWD}/src/hcf-release
-export FISSILE_ROLE_MANIFEST=${PWD}/role-manifest.yml
-export FISSILE_LIGHT_OPINIONS=${PWD}/opinions.yml
-export FISSILE_DARK_OPINIONS=${PWD}/dark-opinions.yml
-export FISSILE_WORK_DIR=${PWD}/work-dir
-export FISSILE_DOCKER_REGISTRY=192.168.122.1:5000
-export FISSILE_REPOSITORY=uaa
+FISSILE_RELEASE=""
+FISSILE_RELEASE="${FISSILE_RELEASE},${PWD}/src/uaa-release"
+FISSILE_RELEASE="${FISSILE_RELEASE},${PWD}/src/cf-mysql-release"
+FISSILE_RELEASE="${FISSILE_RELEASE},${PWD}/src/hcf-release"
+export FISSILE_RELEASE="${FISSILE_RELEASE#,}"
+
+export FISSILE_ROLE_MANIFEST="${PWD}/role-manifest.yml"
+export FISSILE_LIGHT_OPINIONS="${PWD}/opinions.yml"
+export FISSILE_DARK_OPINIONS="${PWD}/dark-opinions.yml"
+export FISSILE_WORK_DIR="${PWD}/work-dir"
+export FISSILE_REPOSITORY="uaa"
+
+# The following is for fish support: run this script as `bash $0 fish`, and it
+# will print out the fish commands for you to source.
+if test "${BASH_ARGV:+${BASH_ARGV[0]}}" = "fish" ; then
+    for var in $(env | grep -E '^FISSILE_' | cut -d= -f1) ; do
+        echo "set -x ${var} '${!var}'"
+    done
+fi
+
+if ! type source_up >/dev/null 2>/dev/null; then
+    # Restore the variable from the start of the script
+    PWD="$(pwd)"
+fi


### PR DESCRIPTION
Instead of using direnv, `source .envrc` should now also work correctly. For fish users, `bash .envrc fish | source` is required.

This should work with fish (special syntax), bash, ksh, and zsh.

See also hpcloud/hcf#919

(I've also removed the `FISSILE_DOCKER_REGISTRY` setting because that wasn't supposed to be there — it was a thing I had locally that got accidentally checked in. Other people don't have a docker registry there.)