### PR TITLE
Extend the monit timeout for UAA

### DIFF
--- a/role-manifest.yml
+++ b/role-manifest.yml
@@ -77,6 +77,8 @@ roles:
 - name: uaa
   environment_scripts:
   - scripts/configure-HA-hosts.sh
+  scripts:
+  - scripts/patches/uaa_monit_timeout.sh
   jobs:
   - name: global-properties # needs to be first so images use it for processing monit templates
     release_name: hcf

--- a/scripts/patches/uaa_monit_timeout.sh
+++ b/scripts/patches/uaa_monit_timeout.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# On lower-end machines (e.g. vagrant box for development), UAA might
+# take too long to start.  Extend the timeout to avoid that.
+
+set -o errexit -o nounset
+
+PATCH_DIR="/var/vcap/jobs-src/uaa/"
+SENTINEL="${PATCH_DIR}/${0##*/}.sentinel"
+
+if [ -f "${SENTINEL}" ]; then
+  exit 0
+fi
+
+cd "${PATCH_DIR}"
+patch --strip=3 --force <<'PATCH'
+diff --git a/jobs/uaa/monit b/jobs/uaa/monit
+index d7bd9dc..4524ca1 100644
+--- a/jobs/uaa/monit
++++ b/jobs/uaa/monit
+@@ -5,6 +5,6 @@ check process uaa
+   group vcap
+   if failed port 8989 protocol http
+     request "/healthz"
+-    with timeout 60 seconds for 15 cycles
++    with timeout 600 seconds for 15 cycles
+   then restart
+PATCH
+
+touch "${SENTINEL}"


### PR DESCRIPTION
On a vagrant box it might be too slow to finish the initial database migration (from nothing) within a minute.