### PR TITLE
Remove pre-v5 commands, and added stemcell information 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -28,6 +28,9 @@ export FISSILE_DARK_OPINIONS="${PWD}/dark-opinions.yml"
 export FISSILE_WORK_DIR="${PWD}/work-dir"
 export FISSILE_REPOSITORY="uaa"
 
+# The fissile stemcell image that is used as the base
+export FISSILE_STEMCELL=splatform/fissile-stemcell-opensuse:42.2-0.g58a22c9-28.16
+
 # The following is for fish support: run this script as `bash $0 fish`, and it
 # will print out the fish commands for you to source.
 if test "${BASH_ARGV:+${BASH_ARGV[0]}}" = "fish" ; then

--- a/README.md
+++ b/README.md
@@ -58,19 +58,30 @@ go get github.com/square/certstrap
 
 1. Run `generate-certs.sh` to generate the SSL certificates required.  The
     default options are fine.
+
 2. Create the BOSH release for `cf-mysql`, `uaa`, and `hcf`:
     ```
     bosh create release --dir src/cf-mysql-release --force --name cf-mysql
     bosh create release --dir src/uaa-release --force --name uaa
     bosh create release --dir src/hcf-release --force --name hcf
     ```
+
 3. Build fissile images
     ```
-    fissile build layer compilation
-    fissile build layer stemcell
-    fissile build packages
-    fissile build images
+    STEMCELL=splatform/fissile-stemcell-opensuse:42.2-0.g58a22c9-28.16
+    fissile build packages --stemcell ${STEMCELL}
+    fissile build images   --stemcell ${STEMCELL}
     ```
+
+Or, more convenient
+
+    ```
+    make images
+    ```
+
+Note, the specified stemcell is an example. Change it to suit.  The
+alternative command uses the definition of `FISSILE_STEMCELL` in
+`.envrc` for this.
 
 ## Running
 

--- a/make/images
+++ b/make/images
@@ -6,7 +6,5 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
 cd "$GIT_ROOT"
 . ${GIT_ROOT}/.envrc
-fissile build layer compilation
-fissile build layer stemcell
-fissile build packages
-fissile build images
+fissile build packages --stemcell ${FISSILE_STEMCELL}
+fissile build images   --stemcell ${FISSILE_STEMCELL}


### PR DESCRIPTION
As per SCF branch `fix_hcf_on_opensuse_for_real`.
Updated README.

Trello: https://trello.com/c/2aEtxEpM/162-(2)-uaa-needs-to-work-with-fissile-5.0.0
