### PR TITLE
Bump cf-mysql-release to v34

### DIFF
--- a/opinions.yml
+++ b/opinions.yml
@@ -2,7 +2,6 @@
 properties:
   cf_mysql:
     mysql:
-      database_startup_timeout: 300
       galera_healthcheck:
         endpoint_username: galera_healthcheck_bootstrap_user
       max_open_files: 1500


### PR DESCRIPTION
This fixes a socat compile error in xip-io.c.

https://github.com/cloudfoundry/cf-mysql-release/commit/6554e39dc138b3d2e6eeb0ef8a7cb5d47730ae8b