### PR TITLE
Don't override the fissile work dir if it's set

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -25,9 +25,9 @@ export FISSILE_RELEASE="${FISSILE_RELEASE#,}"
 export FISSILE_ROLE_MANIFEST="${PWD}/role-manifest.yml"
 export FISSILE_LIGHT_OPINIONS="${PWD}/opinions.yml"
 export FISSILE_DARK_OPINIONS="${PWD}/dark-opinions.yml"
-export FISSILE_WORK_DIR="$HOME/.fissile/uaa-work-dir"
+export FISSILE_WORK_DIR="${FISSILE_WORK_DIR:-$HOME/.fissile/uaa-work-dir}"
 export FISSILE_REPOSITORY="uaa"
-export FISSILE_CACHE_DIR="$HOME/.bosh/cache"
+export FISSILE_CACHE_DIR="${FISSILE_CACHE_DIR:-$HOME/.bosh/cache}"
 
 # The fissile stemcell image that is used as the base
 export FISSILE_STEMCELL=splatform/fissile-stemcell-opensuse:42.2-6.ga651b2d-28.33


### PR DESCRIPTION
This makes it possible to reuse the cache when using SCF