### PR TITLE
Removed `IMAGE_` variables and replaced with the proper `FISSILE_`'s.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -16,6 +16,12 @@ if test -d ../fissile/build/linux-amd64/ ; then
     PATH="$(cd ../fissile/build/linux-amd64/ && pwd)${PATH:+:${PATH}}"
 fi
 
+# The Docker repository name used for images, the registry itself, and the org to use.
+# Note, this replaces "make/include/registry" and its IMAGE_* variables
+export FISSILE_REPOSITORY="uaa"
+export FISSILE_DOCKER_REGISTRY="${FISSILE_DOCKER_REGISTRY:+${FISSILE_DOCKER_REGISTRY%/}/}"
+export FISSILE_DOCKER_ORGANIZATION=splatform
+
 FISSILE_RELEASE=""
 FISSILE_RELEASE="${FISSILE_RELEASE},${PWD}/src/uaa-release"
 FISSILE_RELEASE="${FISSILE_RELEASE},${PWD}/src/cf-mysql-release"
@@ -26,7 +32,6 @@ export FISSILE_ROLE_MANIFEST="${PWD}/role-manifest.yml"
 export FISSILE_LIGHT_OPINIONS="${PWD}/opinions.yml"
 export FISSILE_DARK_OPINIONS="${PWD}/dark-opinions.yml"
 export FISSILE_WORK_DIR="${FISSILE_WORK_DIR:-$HOME/.fissile/uaa-work-dir}"
-export FISSILE_REPOSITORY="uaa"
 export FISSILE_CACHE_DIR="${FISSILE_CACHE_DIR:-$HOME/.bosh/cache}"
 
 # The fissile stemcell image that is used as the base

--- a/.envrc
+++ b/.envrc
@@ -18,9 +18,9 @@ fi
 
 # The Docker repository name used for images, the registry itself, and the org to use.
 # Note, this replaces "make/include/registry" and its IMAGE_* variables
-export FISSILE_REPOSITORY="uaa"
+export FISSILE_REPOSITORY=${FISSILE_REPOSITORY:-uaa}
 export FISSILE_DOCKER_REGISTRY="${FISSILE_DOCKER_REGISTRY:+${FISSILE_DOCKER_REGISTRY%/}/}"
-export FISSILE_DOCKER_ORGANIZATION=splatform
+export FISSILE_DOCKER_ORGANIZATION=${FISSILE_DOCKER_ORGANIZATION:-'splatform'}
 
 FISSILE_RELEASE=""
 FISSILE_RELEASE="${FISSILE_RELEASE},${PWD}/src/uaa-release"

--- a/make/images
+++ b/make/images
@@ -6,6 +6,6 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
 cd "$GIT_ROOT"
 . "${GIT_ROOT}/.envrc"
-. "${GIT_ROOT}/make/include/registry"
-fissile build packages --stemcell "${FISSILE_STEMCELL}"
-fissile build images   --stemcell "${FISSILE_STEMCELL}" --docker-registry "${IMAGE_REGISTRY}" --docker-organization "${IMAGE_ORG}" --repository "${IMAGE_PREFIX}"
+
+fissile build packages
+fissile build images

--- a/make/include/registry
+++ b/make/include/registry
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -o errexit -o nounset
-
-IMAGE_ORG=${IMAGE_ORG:-'splatform'}
-IMAGE_PREFIX=${IMAGE_PREFIX:-'uaa'}
-IMAGE_REGISTRY="${IMAGE_REGISTRY:+${IMAGE_REGISTRY%/}/}"

--- a/make/kube-configs
+++ b/make/kube-configs
@@ -4,16 +4,13 @@ set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
-# TODO: We currently skip memory limits for development purposes
+. "${GIT_ROOT}/.envrc"
 
-. "${GIT_ROOT}/make/include/registry"
+# TODO: We currently skip memory limits for development purposes
 
 cd "$GIT_ROOT"
 . ${GIT_ROOT}/.envrc
 fissile build kube \
     --kube-output-dir="${GIT_ROOT}/kube" \
     --defaults-file="$(echo env/*.env | tr ' ' ',')" \
-    --use-memory-limits=false \
-    --docker-registry "${IMAGE_REGISTRY}" \
-    --docker-organization "${IMAGE_ORG}" \
-    --repository "${IMAGE_PREFIX}"
+    --use-memory-limits=false

--- a/make/publish
+++ b/make/publish
@@ -5,9 +5,8 @@ set -o errexit -o nounset
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
 . "${GIT_ROOT}/.envrc"
-. "${GIT_ROOT}/make/include/registry"
 
-BOSH_IMAGES=${BOSH_IMAGES:-$(fissile show image --docker-registry "${IMAGE_REGISTRY}" --docker-organization "${IMAGE_ORG}" --repository "${IMAGE_PREFIX}")}
+BOSH_IMAGES=${BOSH_IMAGES:-$(fissile show image)}
 
 for image in ${BOSH_IMAGES}; do
     # Redirect docker stdout to avoid polluting logfiles with progressbar characters


### PR DESCRIPTION
https://trello.com/c/QlFH99Qh/172-2-make-images-and-fissile-build-images-should-be-the-same

Moved definition into .envrc.
Removed the now superfluous `make/include/registry`.
Updated the scripts, removed superfluous options in `fissile` calls.