### PR TITLE
Fix hardcoded FISSILE_STEMCELL version for opensuse 42.2

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -35,7 +35,7 @@ export FISSILE_WORK_DIR="${FISSILE_WORK_DIR:-$HOME/.fissile/uaa-work-dir}"
 export FISSILE_CACHE_DIR="${FISSILE_CACHE_DIR:-$HOME/.bosh/cache}"
 
 # The fissile stemcell image that is used as the base
-export FISSILE_STEMCELL=splatform/fissile-stemcell-opensuse:42.2-6.ga651b2d-28.33
+export FISSILE_STEMCELL=${FISSILE_STEMCELL:-splatform/fissile-stemcell-opensuse:42.2-6.ga651b2d-28.33}
 
 # The following is for fish support: run this script as `bash $0 fish`, and it
 # will print out the fish commands for you to source.


### PR DESCRIPTION
This PR allows `$FISSILE_STEMCELL` to be overriden.