### PR TITLE
Add `make helm-chart` target and use helm chart in `make run`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 /src/*-release/config/dev.yml
 /src/*-release/dev_releases/
 /kube
+/helm
 /*.zip
 uaa_metrics.csv

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for SUSE UAA
+name: uaa
+version: 4.0.1

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ helm:
 publish:
 	${GIT_ROOT}/make/publish
 
-.PHONY: build certs releases images kube kube-dist publish
+.PHONY: build certs releases images kube kube-dist helm publish
 
 
 run: kube/bosh/uaa.yml

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ kube kube/bosh/uaa.yml:
 kube-dist:
 	${GIT_ROOT}/make/kube-dist
 
+helm:
+	${GIT_ROOT}/make/kube helm
+
 publish:
 	${GIT_ROOT}/make/publish
 

--- a/make/kube
+++ b/make/kube
@@ -3,14 +3,26 @@
 set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
+cd "${GIT_ROOT}"
+source .envrc
 
-. "${GIT_ROOT}/.envrc"
+ENV_FILES="$(echo env/*.env)"
+
+CREATE_HELM_CHART=false
+KUBE_OUTPUT_DIR=kube
+
+if [ "${1:-}" = "helm" ]; then
+    CREATE_HELM_CHART=true
+    KUBE_OUTPUT_DIR=helm
+    ENV_FILES=env/certs.env
+fi
+
+rm -rf ${KUBE_OUTPUT_DIR}
 
 # TODO: We currently skip memory limits for development purposes
-
-cd "$GIT_ROOT"
-
 fissile build kube \
-    --kube-output-dir="${GIT_ROOT}/kube" \
-    --defaults-file="$(echo env/*.env | tr ' ' ',')" \
-    --use-memory-limits=false
+    --kube-output-dir="${KUBE_OUTPUT_DIR}" \
+    --defaults-file="$(echo "${ENV_FILES}" | tr ' ' ,)" \
+    --use-memory-limits=false \
+    --create-helm-chart=${CREATE_HELM_CHART} \
+    --chart-file=Chart.yaml

--- a/make/kube
+++ b/make/kube
@@ -9,20 +9,18 @@ source .envrc
 ENV_FILES="$(echo env/*.env)"
 
 CREATE_HELM_CHART=false
-KUBE_OUTPUT_DIR=kube
+BUILD_TARGET=kube
 
 if [ "${1:-}" = "helm" ]; then
     CREATE_HELM_CHART=true
-    KUBE_OUTPUT_DIR=helm
+    BUILD_TARGET=helm
     ENV_FILES=env/certs.env
 fi
 
-rm -rf ${KUBE_OUTPUT_DIR}
+rm -rf "${BUILD_TARGET}"
 
 # TODO: We currently skip memory limits for development purposes
-fissile build kube \
-    --kube-output-dir="${KUBE_OUTPUT_DIR}" \
+fissile build "${BUILD_TARGET}" \
+    --output-dir="${BUILD_TARGET}" \
     --defaults-file="$(echo "${ENV_FILES}" | tr ' ' ,)" \
-    --use-memory-limits=false \
-    --create-helm-chart=${CREATE_HELM_CHART} \
-    --chart-file=Chart.yaml
+    --use-memory-limits=false

--- a/make/run
+++ b/make/run
@@ -32,10 +32,11 @@ kubectl get storageclass persistent 2>/dev/null || {
     kubectl create -f -
 }
 
-kubectl create --namespace="${NAMESPACE}" \
-    --filename="kube/bosh" \
-    --filename="kube/secrets" \
-    --filename="kube-test/exposed-ports.yml"
+source env/defaults.env
+helm install helm \
+     --namespace "${NAMESPACE}" \
+     --set "env.DOMAIN=${DOMAIN}" \
+     --set "env.UAA_ADMIN_CLIENT_SECRET=${UAA_ADMIN_CLIENT_SECRET}"
 
 stampy "${GIT_ROOT}/uaa_metrics.csv" "$0" make-run::create end
 

--- a/role-manifest.yml
+++ b/role-manifest.yml
@@ -108,7 +108,7 @@ roles:
         protocol: TCP
         external: 2793
         internal: 8443
-        public: false
+        public: true
     healthcheck:
       liveness:
         initial_delay: 1800
@@ -127,6 +127,7 @@ configuration:
     description: >
       Base domain name of the UAA endpoint; `uaa.${DOMAIN}` must be correctly
       configured to point to this UAA instance
+    required: true
   - name: HCP_COMPONENT_INDEX
     type: environment
   - name: HCP_SERVICE_DOMAIN_SUFFIX
@@ -190,8 +191,6 @@ configuration:
   - name: UAA_ADMIN_CLIENT_SECRET
     secret: true
     immutable: true
-    generator:
-      type: Password
     description: The password of the admin client - a client named admin with uaa.admin as an authority.
   - name: UAA_SERVER_CERT
     secret: true


### PR DESCRIPTION
The Helm chart will auto-generate passwords, but includes all the dev certs
as defaults in values.yaml. Other default settings come from the role manifest
and not from the dev settings.

DOMAIN is a _required_ config variable.

UAA_ADMIN_CLIENT_SECRET must be supplied by the user and not be generated
(the same value needs to be passed to the CF chart).

The UAA port is marked as _public_ so that it becomes reachable from CF.