### PR TITLE
Add /bosh and /helm to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /kube
 /*.zip
 uaa_metrics.csv
+/bosh/
+/helm/


### PR DESCRIPTION
This PR adds the /helm and /bosh directories to .gitignore