### PR TITLE
Increase requested size for mysql's persistent volume

### DIFF
--- a/role-manifest.yml
+++ b/role-manifest.yml
@@ -28,7 +28,7 @@ roles:
     persistent-volumes:
       - path: /var/vcap/store
         tag: mysql-data
-        size: 2
+        size: 20
     shared-volumes: []
     memory: 3072
     virtual-cpus: 2


### PR DESCRIPTION
When running with a kube volume driver that supports quotas, this quickly runs out of disk space, writing ~2.4 GB on startup only.