### PR TITLE
Drop use of xxd in cert generation

### DIFF
--- a/generate-certs.sh
+++ b/generate-certs.sh
@@ -58,7 +58,7 @@ if test "${has_env}" = "no" ; then
 fi
 
 # Generate a random signing key passphrase
-signing_key_passphrase=$(LC_CTYPE=C tr -cd 0-9a-f < /dev/urandom | head -c64)
+signing_key_passphrase=$(head -c32 /dev/urandom | base64)
 
 # build and install `certstrap` tool if it's not installed
 command -v certstrap > /dev/null 2>&1 || {

--- a/generate-certs.sh
+++ b/generate-certs.sh
@@ -58,7 +58,7 @@ if test "${has_env}" = "no" ; then
 fi
 
 # Generate a random signing key passphrase
-signing_key_passphrase=$(head -c 32 /dev/urandom | xxd -ps -c 32)
+signing_key_passphrase=$(LC_CTYPE=C tr -cd 0-9a-f < /dev/urandom | head -c64)
 
 # build and install `certstrap` tool if it's not installed
 command -v certstrap > /dev/null 2>&1 || {


### PR DESCRIPTION
This is a more inefficient passphrase generation method, but it's not slower in practice (/dev/urandom is pretty fast), and drops the requirement of having xxd available (which comes with vim).

Note that the LC_CTYPE change is necessary for macOS/BSD compatibility (they assume actual text and don't accept random bytes as input).

This is cherry-picked from SUSE/scf#1037