### PR TITLE
Use DOMAIN when set for certs, kube, and run:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ifeq ($(GIT_ROOT),)
 GIT_ROOT:=$(shell git rev-parse --show-toplevel)
 endif
 
-build: certs releases images
+build: releases images
 
 certs:
 	${GIT_ROOT}/generate-certs.sh
@@ -14,13 +14,13 @@ releases:
 images:
 	${GIT_ROOT}/make/images
 
-kube kube/bosh/uaa.yaml:
+kube kube/bosh/uaa.yaml: certs
 	${GIT_ROOT}/make/kube
 
 kube-dist:
 	${GIT_ROOT}/make/kube-dist
 
-helm:
+helm: certs
 	${GIT_ROOT}/make/kube helm
 
 publish:
@@ -29,7 +29,7 @@ publish:
 .PHONY: build certs releases images kube kube-dist helm publish
 
 
-run: kube/bosh/uaa.yaml
+run:
 	${GIT_ROOT}/make/run
 
 stop:

--- a/generate-certs.sh
+++ b/generate-certs.sh
@@ -6,6 +6,16 @@ set -o errexit -o nounset
 
 load_env() {
     local dir="${1}"
+    DOMAIN=${DOMAIN:-}
+    if test -n "${DOMAIN}"; then
+        tmp=$(mktemp -d)
+        cp -r "${dir}/"*.env "${tmp}"
+        trap "rm -rf ${tmp}" EXIT
+        if test -f "${tmp}/defaults.env"; then
+            sed -i "s/^DOMAIN=.*/DOMAIN=${DOMAIN}/" "${tmp}/defaults.env"
+        fi
+        dir="${tmp}"
+    fi
     local files=($(find "${dir}" -maxdepth 1 -name '*.env' '(' -name certs.env -o -print ')' | sort))
     if test "${#files[@]}" -lt 1 ; then
         echo "No environment files found in ${dir}" >&2

--- a/make/kube
+++ b/make/kube
@@ -6,7 +6,16 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 cd "${GIT_ROOT}"
 source .envrc
 
-ENV_FILES="$(echo env/*.env)"
+DOMAIN=${DOMAIN:-}
+DEFAULTS_ENV=env/defaults.env
+if test -n "${DOMAIN}"; then
+    TMP="$(mktemp -d)"
+    cp "${DEFAULTS_ENV}" "${TMP}"
+    trap "rm -rf ${TMP}" EXIT
+    DEFAULTS_ENV="${TMP}/$(basename "${DEFAULTS_ENV}")"
+    sed -i "s/^DOMAIN=.*/DOMAIN=${DOMAIN}/" "${DEFAULTS_ENV}"
+fi
+ENV_FILES="env/certs.env $DEFAULTS_ENV"
 
 CREATE_HELM_CHART=false
 BUILD_TARGET=kube

--- a/make/run
+++ b/make/run
@@ -32,11 +32,24 @@ kubectl get storageclass persistent 2>/dev/null || {
     kubectl create -f -
 }
 
-source env/defaults.env
+DOMAIN=${DOMAIN:-}
+DEFAULTS_ENV=env/defaults.env
+
+if test -n "${DOMAIN}"; then
+    TMP="$(mktemp -d)"
+    cp "${DEFAULTS_ENV}" "${TMP}"
+    trap "rm -rf ${TMP}" EXIT
+    DEFAULTS_ENV="${TMP}/$(basename "${DEFAULTS_ENV}")"
+    sed -i "s/^DOMAIN=.*/DOMAIN=${DOMAIN}/" "${DEFAULTS_ENV}"
+fi
+
+source "${DEFAULTS_ENV}"
+
 helm install helm \
      --namespace "${NAMESPACE}" \
      --set "env.DOMAIN=${DOMAIN}" \
-     --set "env.UAA_ADMIN_CLIENT_SECRET=${UAA_ADMIN_CLIENT_SECRET}"
+     --set "env.UAA_ADMIN_CLIENT_SECRET=${UAA_ADMIN_CLIENT_SECRET}" \
+     --set "kube.external_ip=$(dig +short ${DOMAIN})"
 
 stampy "${GIT_ROOT}/uaa_metrics.csv" "$0" make-run::create end
 


### PR DESCRIPTION
This contains the commit used from https://github.com/SUSE/scf/pull/1093

- Clean up case logic around kube vs. helm in make/kube
- Use domain resolution to set external_ip with make run
- Prefer preset DOMAIN for make/run
- Temporarily replace DOMAIN in dotenv file for make/kube and 'make
  certs'

As I point out in the SCF pull request, fissile still hardcodes 192.168.77.77 for external_ip, so that IP will still be used when making kube manifests