### PR TITLE
bin/create-release.sh: Allow customizing version of bosh-cli image

### DIFF
--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -112,7 +112,7 @@ docker run \
     ${proxies} \
     --env MAVEN_OPTS="$MO" \
     --env JAVA_OPTS="$MO" \
-    splatform/bosh-cli \
+    "splatform/bosh-cli:${BOSH_CLI_VERSION:-latest}" \
     /usr/local/bin/create-release.sh \
         "$(id -u)" "$(id -g)" /bosh-cache --dir ${ROOT}/${release_path} --force --name "${release_name}"
 


### PR DESCRIPTION
This is in prepartion for having versioned images so that we can co-ordinate `bosh-cli` image changes across repos.