### PR TITLE
Don't regen certs automatically for helm and kube targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ releases:
 images:
 	make/images
 
-kube kube/bosh/uaa.yaml: certs
+kube kube/bosh/uaa.yaml:
 	make/kube
 
 kube-dist:
 	make/kube-dist
 
-helm: certs
+helm:
 	make/kube helm
 
 publish:

--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,37 @@
 #!/usr/bin/env make
-ifeq ($(GIT_ROOT),)
-GIT_ROOT:=$(shell git rev-parse --show-toplevel)
-endif
 
 build: releases images
 
 certs:
-	${GIT_ROOT}/generate-certs.sh
+	generate-certs.sh
 
 releases:
-	${GIT_ROOT}/make/releases
+	make/releases
 
 images:
-	${GIT_ROOT}/make/images
+	make/images
 
 kube kube/bosh/uaa.yaml: certs
-	${GIT_ROOT}/make/kube
+	make/kube
 
 kube-dist:
-	${GIT_ROOT}/make/kube-dist
+	make/kube-dist
 
 helm: certs
-	${GIT_ROOT}/make/kube helm
+	make/kube helm
 
 publish:
-	${GIT_ROOT}/make/publish
+	make/publish
 
 .PHONY: build certs releases images kube kube-dist helm publish
 
 
 run:
-	${GIT_ROOT}/make/run
+	make/run
 
 stop:
-	${GIT_ROOT}/make/stop
+	make/stop
 
 dist: kube-dist
 
 generate: kube
-


### PR DESCRIPTION
Also gets rid of the `${GIT_ROOT}` noise in the `Makefile`.