### PR TITLE
Enable kube RBAC support and set up service account

### DIFF
--- a/make/run
+++ b/make/run
@@ -49,7 +49,8 @@ helm install helm \
      --namespace "${NAMESPACE}" \
      --set "env.DOMAIN=${DOMAIN}" \
      --set "env.UAA_ADMIN_CLIENT_SECRET=${UAA_ADMIN_CLIENT_SECRET}" \
-     --set "kube.external_ip=$(dig +short ${DOMAIN})"
+     --set "kube.external_ip=$(dig +short ${DOMAIN})" \
+     --set "kube.auth=rbac"
 
 stampy "${GIT_ROOT}/uaa_metrics.csv" "$0" make-run::create end
 

--- a/role-manifest.yml
+++ b/role-manifest.yml
@@ -122,6 +122,18 @@ roles:
     templates:
       properties.uaadb.roles: '[{"name": "uaaadmin", "password": "((UAADB_PASSWORD))", "tag": "admin"}]'
 configuration:
+  auth:
+    roles:
+      configgin-role:
+      - apiGroups: [""]
+        resources: [pods]
+        verbs: [get, list, patch]
+      - apiGroups: [""]
+        resources: [services]
+        verbs: [get]
+    accounts:
+      default:
+        roles: [configgin-role]
   variables:
   - name: DOMAIN
     description: >


### PR DESCRIPTION
This turns on the RBAC support in the new fissile-generated helm charts, and configures a service account to have the permissions necessary to run configgin successfully.