### PR TITLE
role-manifest: allow apps.statefulset/get to configgin roles

### DIFF
--- a/role-manifest.yml
+++ b/role-manifest.yml
@@ -149,6 +149,9 @@ configuration:
       - apiGroups: [""]
         resources: [services]
         verbs: [get]
+      - apiGroups: [apps]
+        resources: [statefulsets]
+        verbs: [get]
       secrets-role:
       - apiGroups: [""]
         resources: [secrets]


### PR DESCRIPTION
This is required for HA (for the pods to find the other instances).

This should resolve [bug 1074197](https://bugzilla.suse.com/show_bug.cgi?id=1074197) (after following up with the SCF side PR).