### PR TITLE
More sightly helm version

### DIFF
--- a/make/kube
+++ b/make/kube
@@ -49,9 +49,9 @@ if [ "${BUILD_TARGET}" = "helm" ]; then
     fi
 
     cat > "${BUILD_TARGET}/Chart.yaml" << EOF
-apiVersion: v1
+apiVersion: ${APP_VERSION}
 description: A Helm chart for SUSE UAA
 name: uaa${chart_name_suffix}
-version: ${APP_VERSION}
+version: ${GIT_TAG}
 EOF
 fi


### PR DESCRIPTION
https://trello.com/c/hu6x06Qz/507-helm-unsightly-versions

Controlling PR = https://github.com/SUSE/scf/pull/1264

Move the extended version information to the `apiVersion` key, and show only the `GIT_TAG` in the `version` key, to make the version information shown by the helm tools more sightly.