### PR TITLE
Fix mutual TLS certs when HA mode is true

### DIFF
--- a/role-manifest.yml
+++ b/role-manifest.yml
@@ -138,7 +138,7 @@ roles:
     service-account: secret-generator
   configuration:
     templates:
-      properties.uaa.secrets.variables: '((DOMAIN))((KUBE_SIZING_UAA_COUNT))'
+      properties.uaa.secrets.variables: '((DOMAIN))'
 configuration:
   auth:
     roles:
@@ -208,10 +208,6 @@ configuration:
     type: environment
   - name: KUBE_SERVICE_DOMAIN_SUFFIX
     type: environment
-  - name: KUBE_SIZING_UAA_COUNT
-    description: >
-      The number of uaa replicas deployed.
-      This value is set automatically by the helm charts of UAA.
   - name: MONIT_PASSWORD
     secret: true
     immutable: true


### PR DESCRIPTION
When HA is set, we never updated the counts in helm; this means that the secret generator didn't know about the correct counts, and therefore did not generate certs which would apply to all the nodes in self-clustering roles.  This fixes the issue by changing the secret generator to create wildcard certificates (limited to the appropriate kubernetes headless services for each role).  We also drop the sizing variables as they are no longer necessary due to the above change.