### PR TITLE
Memory requests based on measuring max memory of the roles in a long-running vagrant

### DIFF
--- a/make/kube
+++ b/make/kube
@@ -35,11 +35,9 @@ fi
 
 rm -rf "${BUILD_TARGET}"
 
-# TODO: We currently skip memory limits for development purposes
 fissile build "${BUILD_TARGET}" \
     --output-dir="${BUILD_TARGET}" \
     --defaults-file="$(echo "${ENV_FILES}" | tr ' ' ,)" \
-    --use-memory-limits=false \
     "${USE_SECRETS_GENERATOR}"
 
 if [ "${BUILD_TARGET}" = "helm" ]; then

--- a/role-manifest.yml
+++ b/role-manifest.yml
@@ -30,7 +30,7 @@ roles:
         tag: mysql-data
         size: 20
     shared-volumes: []
-    memory: 3072
+    memory: 1779
     virtual-cpus: 2
     exposed-ports:
       - name: 'mysql'
@@ -98,7 +98,7 @@ roles:
     capabilities: []
     persistent-volumes: []
     shared-volumes: []
-    memory: 2048
+    memory: 2205
     virtual-cpus: 2
     exposed-ports:
       - name: uaa


### PR DESCRIPTION
Ref: https://trello.com/c/UEvqSutH/576-sane-memory-limits-for-all-pods
See also https://github.com/SUSE/scf/pull/1380
The requests are `max times 3`.
This is based on fissile 5.1.0+89.gfe48877.