### PR TITLE
Allow mysql-proxy to use multiple instances

### DIFF
--- a/role-manifest.yml
+++ b/role-manifest.yml
@@ -18,10 +18,7 @@ roles:
   run:
     scaling:
       min: 1
-      max: 1
-      # mysql-proxy should be active/passive, but it looks like
-      # it is round-robin right now, which doesn't work
-      # ha: 2
+      max: 3
     capabilities: []
     persistent-volumes: []
     shared-volumes: []


### PR DESCRIPTION
The current recommendation is that mysql-proxy behind a load balancer is ok because each instance will point to the same mysql DB instance.