### PR TITLE
Expose log env vars

### DIFF
--- a/role-manifest.yml
+++ b/role-manifest.yml
@@ -330,6 +330,17 @@ configuration:
     generator:
       type: Password
     description: The password for access to the UAA database.
+  - name: SCF_LOG_HOST
+    internal: true
+    description: The log destination to talk to. This has to point to a syslog server.
+  - name: SCF_LOG_PORT
+    internal: true
+    description: The port used by rsyslog to talk to the log destination. If not set it defaults to 514, the standard port of syslog.
+  - name: SCF_LOG_PROTOCOL
+    internal: true
+    default: tcp
+    description: The protocol used by rsyslog to talk to the log destination. The allowed values are tcp, and udp. The default is tcp.
+    required: true
   - name: UAA_ADMIN_CLIENT_SECRET
     secret: true
     immutable: true

--- a/role-manifest.yml
+++ b/role-manifest.yml
@@ -324,12 +324,6 @@ configuration:
       type: Certificate
       value_type: private_key
     description: PEM-encoded key.
-  - name: UAADB_PASSWORD
-    secret: true
-    immutable: true
-    generator:
-      type: Password
-    description: The password for access to the UAA database.
   - name: SCF_LOG_HOST
     internal: true
     description: The log destination to talk to. This has to point to a syslog server.
@@ -341,6 +335,12 @@ configuration:
     default: tcp
     description: The protocol used by rsyslog to talk to the log destination. The allowed values are tcp, and udp. The default is tcp.
     required: true
+  - name: UAADB_PASSWORD
+    secret: true
+    immutable: true
+    generator:
+      type: Password
+    description: The password for access to the UAA database.
   - name: UAA_ADMIN_CLIENT_SECRET
     secret: true
     immutable: true


### PR DESCRIPTION
Ref https://trello.com/c/XLipCaSd/603-uaa-does-not-expose-log-env-vars
Parent: https://github.com/SUSE/scf/pull/1427
