### PR TITLE
Set SCF_LOG_PORT default to 514

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -361,7 +361,8 @@ configuration:
     description: The log destination to talk to. This has to point to a syslog server.
   - name: SCF_LOG_PORT
     internal: true
-    description: The port used by rsyslog to talk to the log destination. If not set it defaults to 514, the standard port of syslog.
+    description: The port used by rsyslog to talk to the log destination. It defaults to 514, the standard port of syslog.
+    default: 514
   - name: SCF_LOG_PROTOCOL
     internal: true
     default: tcp


### PR DESCRIPTION
Despite the claim in the description, it was defaulting to the empty string before, generating invalid URLs.

[trello#DHeMriNz](https://trello.com/c/DHeMriNz)

Cherry picked from SUSE/scf@fc3b2b80f632