### PR TITLE
Set the persistent storage as the default

### DIFF
--- a/kube-test/storage-class-host-path.yml
+++ b/kube-test/storage-class-host-path.yml
@@ -3,6 +3,8 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: persistent
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/host-path
 parameters:
   path: /tmp


### PR DESCRIPTION
Make our persistent storage in the Vagrant box available as the default. This allows the minibroker to provision storage.