### PR TITLE
Rename database role back to mysql

### DIFF
--- a/container-host-files/etc/scf/config/opinions.yml
+++ b/container-host-files/etc/scf/config/opinions.yml
@@ -23,7 +23,7 @@ properties:
         active_key_id: default
     logging_level: INFO
   uaadb:
-    address: database-set
+    address: mysql-set
     databases:
     - name: uaadb
       tag: uaa

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1,6 +1,6 @@
 ---
 instance_groups:
-- name: database
+- name: mysql
   environment_scripts:
   - scripts/configure-HA-hosts.sh
   scripts:
@@ -141,7 +141,7 @@ instance_groups:
     templates:
       properties.uaa.logging_level: ((LOG_LEVEL_LOG4J))((#LOG_LEVEL))((/LOG_LEVEL))
       properties.uaadb.roles: '[{"name": "uaaadmin", "password": "((UAADB_PASSWORD))", "tag": "admin"}]'
-      properties.wait-for-database.hostname: database-set
+      properties.wait-for-database.hostname: mysql-set
       properties.wait-for-database.port: 3306
 - name: secret-generation
   environment_scripts:
@@ -356,7 +356,7 @@ configuration:
     ip: '"((IP_ADDRESS))"'
     networks.default.dns_record_name: '"((#KUBE_COMPONENT_NAME))((KUBE_COMPONENT_NAME))((/KUBE_COMPONENT_NAME))((^KUBE_COMPONENT_NAME))((DNS_RECORD_NAME))((/KUBE_COMPONENT_NAME))"'
     networks.default.ip: '"((IP_ADDRESS))"'
-    properties.cf_mysql.mysql.advertise_host: database-((KUBE_COMPONENT_INDEX)).database-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
+    properties.cf_mysql.mysql.advertise_host: mysql-((KUBE_COMPONENT_INDEX)).mysql-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
     properties.encryption.encryption_keys: '[{"label":"smorgasbrod","passphrase":"((AEK_PASSWORD))"}]'
     properties.fissile.monit.password: '"((MONIT_PASSWORD))"'
     properties.login.saml.serviceProviderCertificate: '"((SAML_SERVICEPROVIDER_CERT))"'


### PR DESCRIPTION
We need additional support to migrate data from previous installation during upgrade if we want to change the names of volume claims.

[trello#aOhLhzFF]