### PR TITLE
[#4yltS6ZB] Remove vagrant-specific .env files. 

### DIFF
--- a/container-host-files/etc/scf/config/env/defaults.env
+++ b/container-host-files/etc/scf/config/env/defaults.env
@@ -1,2 +1,0 @@
-DOMAIN=cf-dev.io
-UAA_ADMIN_CLIENT_SECRET=admin_secret

--- a/make/kube
+++ b/make/kube
@@ -11,31 +11,18 @@ if [ -z "${APP_VERSION:-}" ]; then
   exit 1
 fi
 
-DOMAIN=${DOMAIN:-}
-DEFAULTS_ENV=container-host-files/etc/scf/config/env/defaults.env
-if test -n "${DOMAIN}"; then
-    TMP="$(mktemp -d)"
-    cp "${DEFAULTS_ENV}" "${TMP}"
-    trap "rm -rf ${TMP}" EXIT
-    DEFAULTS_ENV="${TMP}/$(basename "${DEFAULTS_ENV}")"
-    sed -i "s/^DOMAIN=.*/DOMAIN=${DOMAIN}/" "${DEFAULTS_ENV}"
-fi
-ENV_FILES="$DEFAULTS_ENV"
-
 CREATE_HELM_CHART=false
 BUILD_TARGET=kube
 
 if [ "${1:-}" = "helm" ]; then
     CREATE_HELM_CHART=true
     BUILD_TARGET=helm
-    ENV_FILES=
 fi
 
 rm -rf "${BUILD_TARGET}"
 
 fissile build "${BUILD_TARGET}" \
-    --output-dir="${BUILD_TARGET}" \
-    --defaults-file="$(echo "${ENV_FILES}" | tr ' ' ,)"
+    --output-dir="${BUILD_TARGET}"
 
 if [ "${BUILD_TARGET}" = "helm" ]; then
     chart_name_suffix=""

--- a/make/run
+++ b/make/run
@@ -37,25 +37,13 @@ kubectl get storageclass | grep --silent '(default)' 2>/dev/null || {
 }
 STORAGE_CLASS="${STORAGE_CLASS:=$(kubectl get storageclass 2>/dev/null | awk '/(default)/ { print $1 ; exit }')}"
 
-DOMAIN=${DOMAIN:-}
-DEFAULTS_ENV=container-host-files/etc/scf/config/env/defaults.env
-
-if test -n "${DOMAIN}"; then
-    TMP="$(mktemp -d)"
-    cp "${DEFAULTS_ENV}" "${TMP}"
-    # shellcheck disable=SC2064
-    trap "rm -rf ${TMP}" EXIT
-    DEFAULTS_ENV="${TMP}/$(basename "${DEFAULTS_ENV}")"
-    sed -i "s/^DOMAIN=.*/DOMAIN=${DOMAIN}/" "${DEFAULTS_ENV}"
-fi
-
-source "${DEFAULTS_ENV}"
+DOMAIN=${DOMAIN:-cf-dev.io}
 
 helm_args=(
     --name "${NAMESPACE}"
     --namespace "${NAMESPACE}"
+    --values "../../bin/settings.yaml"
     --set "env.DOMAIN=${DOMAIN}"
-    --set "secrets.UAA_ADMIN_CLIENT_SECRET=${UAA_ADMIN_CLIENT_SECRET}"
     --set "kube.external_ips[0]=$(getent hosts "${DOMAIN}" | awk 'NR=1{print $1}')"
     --set "kube.storage_class.persistent=${STORAGE_CLASS}"
 )

--- a/make/upgrade
+++ b/make/upgrade
@@ -19,24 +19,12 @@ echo Upgrading ${NAMESPACE} release \"${RELEASE}\" ...
 stampy "${GIT_ROOT}/uaa_metrics.csv" "$0" make-run start
 stampy "${GIT_ROOT}/uaa_metrics.csv" "$0" make-run::upgrade start
 
-DOMAIN=${DOMAIN:-}
-DEFAULTS_ENV=container-host-files/etc/scf/config/env/defaults.env
-
-if test -n "${DOMAIN}"; then
-    TMP="$(mktemp -d)"
-    cp "${DEFAULTS_ENV}" "${TMP}"
-    # shellcheck disable=SC2064
-    trap "rm -rf ${TMP}" EXIT
-    DEFAULTS_ENV="${TMP}/$(basename "${DEFAULTS_ENV}")"
-    sed -i "s/^DOMAIN=.*/DOMAIN=${DOMAIN}/" "${DEFAULTS_ENV}"
-fi
-
-source "${DEFAULTS_ENV}"
+DOMAIN=${DOMAIN:-cf-dev.io}
 
 helm upgrade ${RELEASE} helm \
      --namespace "${NAMESPACE}" \
+     --values "../../bin/settings.yaml" \
      --set "env.DOMAIN=${DOMAIN}" \
-     --set "secrets.UAA_ADMIN_CLIENT_SECRET=${UAA_ADMIN_CLIENT_SECRET}" \
      --set "kube.external_ips[0]=$(dig +short "${DOMAIN}")" \
      "$@"
 


### PR DESCRIPTION
Ref: https://trello.com/c/4yltS6ZB/817-3-remove-env-files-from-scf-uaa
Primary PR https://github.com/SUSE/scf/pull/1853

Put domain-related default into the scripts. Pull other defaults from a shared file in the SCF repository (assumed to contain us as submodule).