### PR TITLE
Don't reference /var/vcap/packages-src at runtime; it may not exist

### DIFF
--- a/container-host-files/etc/scf/config/scripts/patches/enable_mysql_galera_bootstrap.sh
+++ b/container-host-files/etc/scf/config/scripts/patches/enable_mysql_galera_bootstrap.sh
@@ -30,7 +30,7 @@ PATCH
 
 echo -e "${setup_patch_galera}" | patch --force
 
-PATCH_DIR=$(dirname "$(ls /var/vcap/packages-src/*/bin/wsrep_sst_xtrabackup-v2)")
+PATCH_DIR=$(dirname "$(ls /var/vcap/packages/*/bin/wsrep_sst_xtrabackup-v2)")
 
 cd "$PATCH_DIR"
 


### PR DESCRIPTION
For bpm support all used packages are *moved* into the `/var/vcap/packages` directory, replacing the original symlink.