### PR TITLE
role manifest: shorten some names

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -178,7 +178,7 @@ instance_groups:
           shared-volumes: []
           memory: 256
           virtual-cpus: 1
-          service-account: secret-generator
+          service-account: secret-gen
   configuration:
     templates:
       properties.scf.secrets.cert_expiration: ((CERT_EXPIRATION))
@@ -206,7 +206,7 @@ configuration:
         resources: [configmaps ,secrets]
         verbs: [create, get, list, patch, update, delete]
     cluster-roles:
-      nonprivileged:
+      nonpriv:
       - apiGroups: [extensions]
         resourceNames: [nonprivileged]
         resources: [podsecuritypolicies]
@@ -228,10 +228,10 @@ configuration:
     accounts:
       default:
         roles: [configgin-role]
-        cluster-roles: [nonprivileged]
-      secret-generator:
+        cluster-roles: [nonpriv]
+      secret-gen:
         roles: [configgin-role, secrets-role]
-        cluster-roles: [nonprivileged]
+        cluster-roles: [nonpriv]
   templates:
     index: ((KUBE_COMPONENT_INDEX))((^KUBE_COMPONENT_INDEX))0((/KUBE_COMPONENT_INDEX))
     ip: '"((IP_ADDRESS))"'


### PR DESCRIPTION
We're having issues with some of the kubernetes having names that are too long (e.g. `scf-develop-921-uaa-secret-generator-nonprivileged-cluster-binding`).  As a temporary workaround, shorten some names to below the 63 character mark.  This is pending a real fix in fissile to automatically shorten the generated names where invalid.