### PR TITLE
Revert "Merge pull request #137 from SUSE/marky/sys-resource-kubernetes-resource-name-too-long"

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -178,7 +178,7 @@ instance_groups:
           shared-volumes: []
           memory: 256
           virtual-cpus: 1
-          service-account: secret-gen
+          service-account: secret-generator
   configuration:
     templates:
       properties.scf.secrets.cert_expiration: ((CERT_EXPIRATION))
@@ -206,7 +206,7 @@ configuration:
         resources: [configmaps ,secrets]
         verbs: [create, get, list, patch, update, delete]
     cluster-roles:
-      nonpriv:
+      nonprivileged:
       - apiGroups: [extensions]
         resourceNames: [nonprivileged]
         resources: [podsecuritypolicies]
@@ -228,10 +228,10 @@ configuration:
     accounts:
       default:
         roles: [configgin-role]
-        cluster-roles: [nonpriv]
-      secret-gen:
+        cluster-roles: [nonprivileged]
+      secret-generator:
         roles: [configgin-role, secrets-role]
-        cluster-roles: [nonpriv]
+        cluster-roles: [nonprivileged]
   templates:
     index: ((KUBE_COMPONENT_INDEX))((^KUBE_COMPONENT_INDEX))0((/KUBE_COMPONENT_INDEX))
     ip: '"((IP_ADDRESS))"'


### PR DESCRIPTION
This reverts commit 28cc8fa9259ed751ce6bf1217733f7074044d481, reversing changes made to 0f916fde622a2fce4dc7e688b887f107422a8077.

We have fixed fissile to never generate resource names that are too long, so it is now safe to have sensible things in the role manifest.