### PR TITLE
Ingress resource - add necessary annotations and small refactors

### DIFF
--- a/chart-parts/ingress.yaml
+++ b/chart-parts/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.services.ingress }}
+{{- if .Values.services.ingress -}}
 ---
 # The cert and the key cannot be filled automatically. If we could it
 # would roughly look like the lines below. As is it is the
@@ -14,7 +14,8 @@ apiVersion: "v1"
 kind: "Secret"
 type: kubernetes.io/tls
 metadata:
-  name: "{{ .Release.Namespace }}-secrets-nic"
+  name: "{{ .Values.services.ingress }}-ingress-tls"
+  namespace: "{{ .Release.Namespace }}"
 data:
   tls.crt: ""
   tls.key: ""
@@ -22,14 +23,18 @@ data:
 apiVersion: "extensions/v1beta1"
 kind: "Ingress"
 metadata:
-  name: "ingress-uaa"
-  namespace: {{ .Release.Namespace | quote }}
+  name: "{{ .Release.Name }}-{{ .Values.services.ingress }}"
+  namespace: "{{ .Release.Namespace }}"
   annotations:
-    nginx.ingress.kubernetes.io/secure-backends: "true"
     kubernetes.io/ingress.class: {{ .Values.services.ingress }}
+    {{ if eq .Values.services.ingress "nginx" -}}
+    nginx.ingress.kubernetes.io/secure-backends: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false" # Doesn't enforce HTTPS.
+    {{- end }}
 spec:
   tls:
-  - secretName: "{{ .Release.Namespace }}-secrets-nic"
+  - secretName: "{{ .Values.services.ingress }}-ingress-tls"
     hosts:
     - "*.uaa.{{ .Values.env.DOMAIN }}"
     - "uaa.{{ .Values.env.DOMAIN }}"
@@ -40,12 +45,12 @@ spec:
           - path: "/"
             backend:
               serviceName: "uaa-uaa"
-              servicePort: 2793
+              servicePort: "uaa-ssl"
     - host: "uaa.{{ .Values.env.DOMAIN }}"
       http:
         paths:
           - path: "/"
             backend:
               serviceName: "uaa-uaa"
-              servicePort: 2793
+              servicePort: "uaa-ssl"
 {{- end }}

--- a/chart-parts/ingress.yaml
+++ b/chart-parts/ingress.yaml
@@ -14,7 +14,7 @@ apiVersion: "v1"
 kind: "Secret"
 type: kubernetes.io/tls
 metadata:
-  name: "{{ .Values.services.ingress }}-ingress-tls"
+  name: "{{ .Values.services.ingress.name }}-ingress-tls"
   namespace: "{{ .Release.Namespace }}"
 data:
   tls.crt: ""
@@ -23,18 +23,18 @@ data:
 apiVersion: "extensions/v1beta1"
 kind: "Ingress"
 metadata:
-  name: "{{ .Release.Name }}-{{ .Values.services.ingress }}"
+  name: "{{ .Release.Name }}-{{ .Values.services.ingress.name }}"
   namespace: "{{ .Release.Namespace }}"
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.services.ingress }}
-    {{ if eq .Values.services.ingress "nginx" -}}
+    kubernetes.io/ingress.class: {{ .Values.services.ingress.name }}
+    {{ if eq .Values.services.ingress.name "nginx" -}}
     nginx.ingress.kubernetes.io/secure-backends: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/ssl-redirect: "false" # Doesn't enforce HTTPS.
     {{- end }}
 spec:
   tls:
-  - secretName: "{{ .Values.services.ingress }}-ingress-tls"
+  - secretName: "{{ .Values.services.ingress.name }}-ingress-tls"
     hosts:
     - "*.uaa.{{ .Values.env.DOMAIN }}"
     - "uaa.{{ .Values.env.DOMAIN }}"
@@ -45,12 +45,12 @@ spec:
           - path: "/"
             backend:
               serviceName: "uaa-uaa"
-              servicePort: "uaa-ssl"
+              servicePort: {{ .Values.services.ingress.uaa_backend_port }}
     - host: "uaa.{{ .Values.env.DOMAIN }}"
       http:
         paths:
           - path: "/"
             backend:
               serviceName: "uaa-uaa"
-              servicePort: "uaa-ssl"
+              servicePort: {{ .Values.services.ingress.uaa_backend_port }}
 {{- end }}

--- a/chart-parts/ingress.yaml
+++ b/chart-parts/ingress.yaml
@@ -14,7 +14,7 @@ apiVersion: "v1"
 kind: "Secret"
 type: kubernetes.io/tls
 metadata:
-  name: "{{ .Values.services.ingress.name }}-ingress-tls"
+  name: "{{ .Values.services.ingress.class }}-ingress-tls"
   namespace: "{{ .Release.Namespace }}"
 data:
   tls.crt: ""
@@ -23,18 +23,18 @@ data:
 apiVersion: "extensions/v1beta1"
 kind: "Ingress"
 metadata:
-  name: "{{ .Release.Name }}-{{ .Values.services.ingress.name }}"
+  name: "{{ .Release.Name }}-{{ .Values.services.ingress.class }}"
   namespace: "{{ .Release.Namespace }}"
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.services.ingress.name }}
-    {{ if eq .Values.services.ingress.name "nginx" -}}
+    kubernetes.io/ingress.class: {{ .Values.services.ingress.class }}
+    {{ if eq .Values.services.ingress.class "nginx" -}}
     nginx.ingress.kubernetes.io/secure-backends: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/ssl-redirect: "false" # Doesn't enforce HTTPS.
     {{- end }}
 spec:
   tls:
-  - secretName: "{{ .Values.services.ingress.name }}-ingress-tls"
+  - secretName: "{{ .Values.services.ingress.class }}-ingress-tls"
     hosts:
     - "*.uaa.{{ .Values.env.DOMAIN }}"
     - "uaa.{{ .Values.env.DOMAIN }}"
@@ -45,12 +45,12 @@ spec:
           - path: "/"
             backend:
               serviceName: "uaa-uaa"
-              servicePort: {{ .Values.services.ingress.uaa_backend_port }}
+              servicePort: {{ .Values.services.ingress.backends.uaa.port }}
     - host: "uaa.{{ .Values.env.DOMAIN }}"
       http:
         paths:
           - path: "/"
             backend:
               serviceName: "uaa-uaa"
-              servicePort: {{ .Values.services.ingress.uaa_backend_port }}
+              servicePort: {{ .Values.services.ingress.backends.uaa.port }}
 {{- end }}


### PR DESCRIPTION
## Description

- Adds missing NGINX Ingress Controller annotations.
- Changes the name of the resources to more meaningful ones (not tied to a specific Ingress Controller).
- Injects the UAA backend port.

## Test plan

Will be part of SCF.