### PR TITLE
Ingress controller - fix variable not set error

### DIFF
--- a/make/run
+++ b/make/run
@@ -47,7 +47,7 @@ helm_args=(
     --set "kube.storage_class.persistent=${STORAGE_CLASS}"
 )
 
-if [ -n "${INGRESS_CONTROLLER}" ]; then
+if [ -n "${INGRESS_CONTROLLER:-}" ]; then
     helm_args+=(
         --set "services.ingress.class=${INGRESS_CONTROLLER}"
         --set "services.ingress.backends.uaa.port=2793"

--- a/make/upgrade
+++ b/make/upgrade
@@ -27,7 +27,7 @@ helm_args=(
     --set "env.DOMAIN=${DOMAIN}"
 )
 
-if [ -n "${INGRESS_CONTROLLER}" ]; then
+if [ -n "${INGRESS_CONTROLLER:-}" ]; then
     helm_args+=(
         --set "services.ingress.class=${INGRESS_CONTROLLER}"
         --set "services.ingress.backends.uaa.port=2793"


### PR DESCRIPTION
## Test plan

The scripts run when `INGRESS_CONTROLLER` is not set.