### PR TITLE
Bump uaa to 6.2.0 releases.

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1,13 +1,13 @@
 ---
 releases:
 - name: cf-mysql
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-mysql-release?v=36.15.0
-  version: 36.15.0
-  sha1: 0764d9d6aae7cefd10019437ed83e7715e614633
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-mysql-release?v=36.16.0
+  version: 36.16.0
+  sha1: eb028b258599e465f9fabb395b87e0093c46aa98
 - name: uaa
-  version: "64.0"
-  url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=64.0"
-  sha1: "f10caefdd136675975bfc88d6409f322c68209d4"
+  version: "66.0"
+  url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=66.0"
+  sha1: "2848d9fb65d2d556a918e8045359cf469c241123"
 - name: "scf-helper"
   version: "1.0.1"
   url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.1.tgz"


### PR DESCRIPTION
Ref: https://trello.com/c/jKAvgx6W/929-5-post-131-cf-big-bump-part-2-as-most-recent-as-possible

Actually no change for 6.3. This has the bump to 6.2 releases as PR.

Controlling PR https://github.com/SUSE/scf/pull/2171
