### PR TITLE
Bumping uaa and cf-mysql release for CF Bump to v6.10

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -1,17 +1,17 @@
 ---
 releases:
 - name: cf-mysql
-  url: https://bosh.io/d/github.com/cloudfoundry/cf-mysql-release?v=36.16.0
-  version: 36.16.0
-  sha1: eb028b258599e465f9fabb395b87e0093c46aa98
+  version: 36.17.0
+  url: https://bosh.io/d/github.com/cloudfoundry/cf-mysql-release?v=36.17.0
+  sha1: 04cbfafa0a2c11b133da20de8282595c98bc0049
 - name: uaa
-  version: "67.0"
-  url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=67.0"
-  sha1: "b07e17aff8caaf36d7c8263f5b0cd2cf64f1ad1f"
-- name: "scf-helper"
-  version: "1.0.1"
-  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.1.tgz"
-  sha1: "94bb4357cbe5fa07ddeb7efef1d1f7a2af8dfead"
+  version: 68.0
+  url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=68.0
+  sha1: a06e5390463c760bcbcc0bacaec063f41a5ea089
+- name: scf-helper
+  version: 1.0.1
+  url: https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.1.tgz
+  sha1: 94bb4357cbe5fa07ddeb7efef1d1f7a2af8dfead
 
 instance_groups:
 - name: mysql


### PR DESCRIPTION
Original PR for `6.10` bump: https://github.com/SUSE/scf/pull/2235