### PR TITLE
Improved Ingress resource template

### DIFF
--- a/chart-parts/ingress.yaml
+++ b/chart-parts/ingress.yaml
@@ -1,5 +1,10 @@
 {{- if .Values.ingress.enabled -}}
 ---
+# The certificate and key for the TLS secret are passed through ingress.tls.crt and ingress.tls.key
+# respectively. If the operator does not provide these values at installation time, the TLS secret
+# will contain empty values. The standard behaviour for NGINX ingress controller is to provide a
+# fake certificate instead. It is useful only for testing and development. It is expected that for
+# production use the operator will provide these values.
 apiVersion: "v1"
 kind: "Secret"
 type: kubernetes.io/tls

--- a/chart-parts/ingress.yaml
+++ b/chart-parts/ingress.yaml
@@ -21,21 +21,19 @@ metadata:
   name: {{ .Release.Name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   annotations:
-    {{- if empty (index .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-    kubernetes.io/ingress.class: "nginx"
+    {{- if hasKey .Values.ingress.annotations "kubernetes.io/ingress.class" | not -}}
+      {{ $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" "nginx" }}
     {{- end }}
-    {{- if empty (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/secure-backends") }}
-    nginx.ingress.kubernetes.io/secure-backends: "true"
+    {{- if hasKey .Values.ingress.annotations "nginx.ingress.kubernetes.io/secure-backends" | not -}}
+      {{ $_ := set .Values.ingress.annotations "nginx.ingress.kubernetes.io/secure-backends" "true" }}
     {{- end }}
-    {{- if empty (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/backend-protocol") }}
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    {{- if hasKey .Values.ingress.annotations "nginx.ingress.kubernetes.io/backend-protocol" | not -}}
+      {{ $_ := set .Values.ingress.annotations "nginx.ingress.kubernetes.io/backend-protocol" "HTTPS" }}
     {{- end }}
-    {{- if empty (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/ssl-redirect") }}
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- if hasKey .Values.ingress.annotations "nginx.ingress.kubernetes.io/ssl-redirect" | not -}}
+      {{ $_ := set .Values.ingress.annotations "nginx.ingress.kubernetes.io/ssl-redirect" "false" }}
     {{- end }}
-{{- if not (empty .Values.ingress.annotations)}}
 {{ toYaml .Values.ingress.annotations | indent 4 }}
-{{- end }}
 spec:
   tls:
   - secretName: "ingress-tls"

--- a/chart-parts/ingress.yaml
+++ b/chart-parts/ingress.yaml
@@ -1,40 +1,39 @@
-{{- if .Values.services.ingress -}}
+{{- if .Values.ingress.enabled -}}
 ---
-# The cert and the key cannot be filled automatically. If we could it
-# would roughly look like the lines below. As is it is the
-# responsibility of the operator to retrieve the values of these
-# secrets from the deployed UAA and update this secret with the actual
-# values. And the responsibility of the developer to supply the proper
-# instructions to the operator.
-##
-# tls.crt: {{ default "" .Values.secrets.UAA_SERVER_CERT     | b64enc | quote }}
-# tls.key: {{ default "" .Values.secrets.UAA_SERVER_CERT_KEY | b64enc | quote }}
-
 apiVersion: "v1"
 kind: "Secret"
 type: kubernetes.io/tls
 metadata:
-  name: "{{ .Values.services.ingress.class }}-ingress-tls"
-  namespace: "{{ .Release.Namespace }}"
+  name: "ingress-tls"
+  namespace: {{ .Release.Namespace | quote }}
 data:
-  tls.crt: ""
-  tls.key: ""
+  tls.crt: {{ .Values.ingress.tls.crt | default "" | b64enc | quote }}
+  tls.key: {{ .Values.ingress.tls.key | default "" | b64enc | quote }}
 ---
 apiVersion: "extensions/v1beta1"
 kind: "Ingress"
 metadata:
-  name: "{{ .Release.Name }}-{{ .Values.services.ingress.class }}"
-  namespace: "{{ .Release.Namespace }}"
+  name: {{ .Release.Name | quote }}
+  namespace: {{ .Release.Namespace | quote }}
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.services.ingress.class }}
-    {{ if eq .Values.services.ingress.class "nginx" -}}
-    nginx.ingress.kubernetes.io/secure-backends: "true"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/ssl-redirect: "false" # Doesn't enforce HTTPS.
+    {{- if empty (index .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+    kubernetes.io/ingress.class: "nginx"
     {{- end }}
+    {{- if empty (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/secure-backends") }}
+    nginx.ingress.kubernetes.io/secure-backends: "true"
+    {{- end }}
+    {{- if empty (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/backend-protocol") }}
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    {{- end }}
+    {{- if empty (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/ssl-redirect") }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
+{{- if not (empty .Values.ingress.annotations)}}
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- end }}
 spec:
   tls:
-  - secretName: "{{ .Values.services.ingress.class }}-ingress-tls"
+  - secretName: "ingress-tls"
     hosts:
     - "*.uaa.{{ .Values.env.DOMAIN }}"
     - "uaa.{{ .Values.env.DOMAIN }}"
@@ -45,12 +44,12 @@ spec:
           - path: "/"
             backend:
               serviceName: "uaa-uaa"
-              servicePort: {{ .Values.services.ingress.backends.uaa.port }}
+              servicePort: 2793
     - host: "uaa.{{ .Values.env.DOMAIN }}"
       http:
         paths:
           - path: "/"
             backend:
               serviceName: "uaa-uaa"
-              servicePort: {{ .Values.services.ingress.backends.uaa.port }}
+              servicePort: 2793
 {{- end }}

--- a/make/run
+++ b/make/run
@@ -49,8 +49,8 @@ helm_args=(
 
 if [ -n "${INGRESS_CONTROLLER:-}" ]; then
     helm_args+=(
-        --set "services.ingress.class=${INGRESS_CONTROLLER}"
-        --set "services.ingress.backends.uaa.port=2793"
+        --set "ingress.enabled=true"
+        --set "ingress.annotations.kubernetes\.io\/ingress\.class=${INGRESS_CONTROLLER}"
         --set "env.UAA_PUBLIC_PORT=443"
     )
 else

--- a/make/upgrade
+++ b/make/upgrade
@@ -29,8 +29,8 @@ helm_args=(
 
 if [ -n "${INGRESS_CONTROLLER:-}" ]; then
     helm_args+=(
-        --set "services.ingress.class=${INGRESS_CONTROLLER}"
-        --set "services.ingress.backends.uaa.port=2793"
+        --set "ingress.enabled=true"
+        --set "ingress.annotations.kubernetes\.io\/ingress\.class=${INGRESS_CONTROLLER}"
         --set "env.UAA_PUBLIC_PORT=443"
     )
 else


### PR DESCRIPTION
## Description

- Aligned better with the practices seen on stable/charts.
- Allowed passing `ingress.tls.crt` and `ingress.tls.key`.
- Allowed passing `ingress.annotations`, and handling default annotations.
- Hardcoded UAA port as it is not modifiable.
- Updated make scripts to reflect the changes.

Ties to:
- https://github.com/cloudfoundry-incubator/fissile/pull/491
- https://github.com/SUSE/scf/pull/2305

## Test plan

Part of https://github.com/SUSE/scf/pull/2305.