### PR TITLE
role-manifest: allow configgin-roles to patch statefulsets

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -200,7 +200,7 @@ configuration:
         verbs: [get]
       - apiGroups: [apps]
         resources: [statefulsets]
-        verbs: [get]
+        verbs: [get, patch]
       secrets-role:
       - apiGroups: [""]
         resources: [configmaps ,secrets]


### PR DESCRIPTION
This is to implement restarting dependent pods on exported BOSH property change; see https://github.com/cloudfoundry-incubator/configgin/pull/97 and https://github.com/cloudfoundry-incubator/fissile/pull/470