### PR TITLE
Don't use cluster roles; regular roles are good enough

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -204,14 +204,13 @@ configuration:
       - apiGroups: [""]
         resources: [configmaps ,secrets]
         verbs: [create, get, list, patch, update, delete]
-    cluster-roles:
-      nonprivileged:
+      psp-role:
       - apiGroups: [extensions]
-        resourceNames: [nonprivileged]
+        resourceNames: [default]
         resources: [podsecuritypolicies]
         verbs: [use]
     pod-security-policies:
-      nonprivileged:
+      default:
         fsGroup: { rule: RunAsAny }
         runAsUser: { rule: RunAsAny }
         seLinux: { rule: RunAsAny }
@@ -226,11 +225,9 @@ configuration:
         - nfs
     accounts:
       default:
-        roles: [configgin-role]
-        cluster-roles: [nonprivileged]
+        roles: [configgin-role, psp-role]
       secret-generator:
-        roles: [configgin-role, secrets-role]
-        cluster-roles: [nonprivileged]
+        roles: [configgin-role, secrets-role, psp-role]
   templates:
     index: ((KUBE_COMPONENT_INDEX))((^KUBE_COMPONENT_INDEX))0((/KUBE_COMPONENT_INDEX))
     ip: '"((IP_ADDRESS))"'


### PR DESCRIPTION
Also changes the name of the "unprivileged" role to "psp-role", and the "unprivileged" pod security policy to "default".