### PR TITLE
Reverted PXC variables renaming

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -107,11 +107,11 @@ instance_groups:
       properties.cf_mysql.mysql.admin_password: ((MYSQL_ADMIN_PASSWORD))
       properties.cf_mysql.mysql.cluster_health.password: ((MYSQL_CLUSTER_HEALTH_PASSWORD))
       properties.cf_mysql.mysql.galera_healthcheck.db_password: ((MYSQL_ADMIN_PASSWORD))
-      properties.cf_mysql.mysql.galera_healthcheck.endpoint_password: ((GALERA_HEALTHCHECK_ENDPOINT_DATABASE_PASSWORD))
+      properties.cf_mysql.mysql.galera_healthcheck.endpoint_password: ((MYSQL_GALERA_HEALTHCHECK_ENDPOINT_PASSWORD))
       # << Deprecation end
 
       properties.db_password: ((MYSQL_ADMIN_PASSWORD))
-      properties.endpoint_password: ((GALERA_HEALTHCHECK_ENDPOINT_DATABASE_PASSWORD))
+      properties.endpoint_password: ((MYSQL_GALERA_HEALTHCHECK_ENDPOINT_PASSWORD))
       properties.engine_config.binlog.enabled: false
       properties.engine_config.galera.enabled: true
       properties.max_open_files: 1500
@@ -182,7 +182,7 @@ instance_groups:
   configuration:
     templates:
       properties.api_force_https: false
-      properties.api_password: ((CF_MYSQL_PROXY_API_PASSWORD))
+      properties.api_password: ((MYSQL_PROXY_ADMIN_PASSWORD))
       properties.api_port: 8083
       properties.api_uri: mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))((#KUBE_SIZING_MYSQL_COUNT))((/KUBE_SIZING_MYSQL_COUNT))
       properties.api_username: mysql_proxy
@@ -353,27 +353,11 @@ variables:
   options:
     description: Expiration for generated certificates (in days)
     default: 10950
-- name: CF_MYSQL_PROXY_API_PASSWORD
-  options:
-    previous_names:
-    - MYSQL_PROXY_ADMIN_PASSWORD
-    secret: true
-    description: The password for Basic Auth used to secure the MySQL proxy API.
-    required: true
-  type: password
 - name: DOMAIN
   options:
     description: Base domain name of the UAA endpoint; `uaa.${DOMAIN}` must be correctly
       configured to point to this UAA instance.
     required: true
-- name: GALERA_HEALTHCHECK_ENDPOINT_DATABASE_PASSWORD
-  options:
-    previous_names:
-    - MYSQL_GALERA_HEALTHCHECK_ENDPOINT_PASSWORD
-    secret: true
-    description: Password used to authenticate to the MySQL Galera healthcheck endpoint.
-    required: true
-  type: password
 - name: GALERA_SERVER_CERT
   options:
     secret: true
@@ -485,6 +469,18 @@ variables:
   options:
     secret: true
     description: The password for the cluster logger health user.
+    required: true
+  type: password
+- name: MYSQL_GALERA_HEALTHCHECK_ENDPOINT_PASSWORD
+  options:
+    secret: true
+    description: Password used to authenticate to the MySQL Galera healthcheck endpoint.
+    required: true
+  type: password
+- name: MYSQL_PROXY_ADMIN_PASSWORD
+  options:
+    secret: true
+    description: The password for Basic Auth used to secure the MySQL proxy API.
     required: true
   type: password
 - name: MYSQL_SERVER_CERT


### PR DESCRIPTION
## Description

These variables got renamed on https://github.com/SUSE/uaa-fissile-release/pull/159 while moving to PXC.

## Test plan

From the latest release to the current version, any upgrades using these variables shouldn't be affected. Also, not setting them should make no difference in the system.
