### PR TITLE
make/run: Delete helm release as appropriate

### DIFF
--- a/make/run
+++ b/make/run
@@ -16,6 +16,11 @@ has_namespace() {
 stampy "${GIT_ROOT}/uaa_metrics.csv" "$0" make-run start
 
 stampy "${GIT_ROOT}/uaa_metrics.csv" "$0" make-run::namespace start
+
+if helm list --short uaa | grep --quiet --line-regexp uaa ; then
+    helm delete --purge uaa
+fi
+
 if has_namespace ; then
     kubectl delete namespace "${NAMESPACE}"
 fi


### PR DESCRIPTION
This makes sure we actually delete the helm release before deleting the namespace.