### PR TITLE
Bump scf-helper-release to stay in sync with SCF

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -17,9 +17,9 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=72.0
   sha1: 7130e5ac640ed1e1f52c09e76995e4d0680f3b45
 - name: scf-helper
-  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.3.tgz"
-  version: "1.0.3"
-  sha1: "c6187d732f0b49f837bdadd0221fe0d91eb55515"
+  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.4.tgz"
+  version: "1.0.4"
+  sha1: "1ac9ec02495ca1660089fdb4343336666fc058eb"
 instance_groups:
 - name: mysql
   scripts:


### PR DESCRIPTION
The new features in scf-secrets-generator will only be used by eirini, so make no difference for this release; it just keeps the versions in sync.

[jsc#CAP-587]