### PR TITLE
Bump scf-helper-release to 1.0.5

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -17,9 +17,9 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=72.0
   sha1: 7130e5ac640ed1e1f52c09e76995e4d0680f3b45
 - name: scf-helper
-  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.4.tgz"
-  version: "1.0.4"
-  sha1: "1ac9ec02495ca1660089fdb4343336666fc058eb"
+  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.5.tgz"
+  version: "1.0.5"
+  sha1: "c06bd583eb655ce9ed562f812ede5a6ace27d9d2"
 instance_groups:
 - name: mysql
   scripts:


### PR DESCRIPTION
Previous build didn't define a default value for the new `scf.secrets.auto_approval` property.