### PR TITLE
Require CAP_AUDIT_WRITE for all containers

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -209,7 +209,7 @@ instance_groups:
             ha: 2
             min: 1
             max: 65535
-          capabilities: []
+          capabilities: [AUDIT_WRITE]
           persistent-volumes: []
           shared-volumes: []
           memory: 2100
@@ -256,7 +256,7 @@ instance_groups:
             min: 1
             max: 1
           flight-stage: pre-flight
-          capabilities: []
+          capabilities: [AUDIT_WRITE]
           persistent-volumes: []
           shared-volumes: []
           memory: 256


### PR DESCRIPTION
Our SLE12 based stemcells might generate audit events via libpam.

[jsc#CAP-571]