### PR TITLE
Add secrets access to configgin role

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -338,9 +338,12 @@ configuration:
       - apiGroups: [apps]
         resources: [statefulsets]
         verbs: [get, patch]
+      - apiGroups: [""]
+        resources: [secrets]
+        verbs: [create, get, delete]
       secrets-role:
       - apiGroups: [""]
-        resources: [configmaps ,secrets]
+        resources: [configmaps, secrets]
         verbs: [create, get, list, patch, update, delete]
       psp-role:
       - apiGroups: [extensions]


### PR DESCRIPTION
This will be required once we switch to the new configgin version that stores exported properties as secrets instead of annotations.

[jsc#CAP-761]