### PR TITLE
make/kube: use correct helm apiVersion

### DIFF
--- a/make/kube
+++ b/make/kube
@@ -31,7 +31,7 @@ if [ "${BUILD_TARGET}" = "helm" ]; then
     fi
 
     cat > "${BUILD_TARGET}/Chart.yaml" << EOF
-apiVersion: ${APP_VERSION}
+apiVersion: v1
 appVersion: ${PRODUCT_VERSION}
 description: A Helm chart for SUSE UAA
 name: uaa${chart_name_suffix}


### PR DESCRIPTION
The apiVersion field in helm's Chart.yaml is for the Helm API version, and not for the app version.  We still have appVersion and version tags.

Fixes jsc#CAP-817