### PR TITLE
Annotate APP_VERSION to a custom Chart field

### DIFF
--- a/make/kube
+++ b/make/kube
@@ -36,6 +36,7 @@ appVersion: ${PRODUCT_VERSION}
 description: A Helm chart for SUSE UAA
 name: uaa${chart_name_suffix}
 version: ${GIT_TAG}
+scfVersion: ${APP_VERSION}
 EOF
     cp chart-parts/* "${BUILD_TARGET}/templates/"
     ruby ../../bin/image-list.rb "${BUILD_TARGET}"


### PR DESCRIPTION
Helm ignores additional fields, and we need to carry on metadata to
identify the chart versioning (cf version, commit hash).

The commit is not only useful to identify the chart, but it is actually
used by pipelines to match SCF tags against the released charts.

Refers to: https://github.com/SUSE/scf/pull/3012