### PR TITLE
Improve startup times

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -17,9 +17,9 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=72.0
   sha1: 7130e5ac640ed1e1f52c09e76995e4d0680f3b45
 - name: scf-helper
-  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.7.tgz"
-  version: "1.0.7"
-  sha1: "d8f4eb845f18dfd89dbad2a7aab7284d81151367"
+  url: "https://s3.amazonaws.com/suse-final-releases/scf-helper-release-1.0.9.tgz"
+  version: "1.0.9"
+  sha1: "8e8c03d7fbd4e7664fc8ebc19fcf3baa3c1c579f"
 instance_groups:
 - name: mysql
   default_feature: mysql

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -206,8 +206,6 @@ instance_groups:
   jobs:
   - name: global-uaa-properties # needs to be first so images use it for processing monit templates
     release: scf-helper
-  - name: wait-for-database
-    release: scf-helper
   - name: uaa
     release: uaa
     properties:
@@ -237,6 +235,8 @@ instance_groups:
           external: 2793
           internal: 8443
           public: true
+  - name: wait-for-database
+    release: scf-helper
   tags:
   - sequential-startup
   configuration:

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -339,7 +339,7 @@ configuration:
         verbs: [get, patch]
       - apiGroups: [""]
         resources: [secrets]
-        verbs: [create, get, delete]
+        verbs: [create, get, update, delete]
       secrets-role:
       - apiGroups: [""]
         resources: [configmaps, secrets]


### PR DESCRIPTION
* Allow configgin to update secrets; will be needed in the next configgin release.

* Import certs into keystore while waiting for mysql to be ready

  Moving the wait-for-database job behind the uaa job means that the uaa pre-start script (which imports the certs) executes before the wait-for-database pre-start script (which waits for the database).

  This works fine because the uaa pre-start script itself doesn't access the database.

* Bump scf-helper-release to 1.0.9 to speedup deployment

  Increases database readiness poll frequency to every 5s.
  Reduces RSA keylength from 4096 to 2048 bits.