### PR TITLE
Remove KUBE_SIZING_MYSQL_COUNT environment variable

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -212,7 +212,7 @@ instance_groups:
       properties.api_force_https: false
       properties.api_password: ((MYSQL_PROXY_ADMIN_PASSWORD))
       properties.api_port: 8083
-      properties.api_uri: mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))((#KUBE_SIZING_MYSQL_COUNT))((/KUBE_SIZING_MYSQL_COUNT))
+      properties.api_uri: mysql-proxy-set.((KUBERNETES_NAMESPACE)).svc.((KUBERNETES_CLUSTER_DOMAIN))
       properties.api_username: mysql_proxy
 
 - name: uaa
@@ -579,10 +579,6 @@ variables:
     description: >
       This is an environment variable built-in by fissile.
       Its default value is 'secret-1' and cannot be set by the user.
-- name: KUBE_SIZING_MYSQL_COUNT
-  options:
-    description: The number of mysql replicas deployed. This value is set automatically
-      by the helm charts of SCF.
 - name: LOG_LEVEL
   options:
     default: info


### PR DESCRIPTION
It is provided by fissile and always corresponds to the number of mysql instances. This used to be used to set `KUBE_MYSQL_CLUSTER_IPS` in `configure-HA-hosts.sh`. But this logic is only used for `nats` anymore, so there is no reason to restart all `mysql-proxy` pods whenever the `mysql` replica count changes.

[jsc#CAP-1148]