### PR TITLE
Make TLS configurable, use proper creds, add user name suffix

### DIFF
--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -137,7 +137,7 @@ instance_groups:
       properties.monit_startup_timeout: 300
       properties.seeded_databases: &seeded_databases >
         [
-          {"name":"uaadb", "username": "uaaadmin", "password":"((UAADB_PASSWORD))"}
+          {"name":"uaadb", "username": "uaaadmin((DB_EXTERNAL_USER_HOST_SUFFIX))", "password":"((UAADB_PASSWORD))"}
         ]
       properties.tls.galera.ca: ((INTERNAL_CA_CERT))
       properties.tls.galera.certificate: ((GALERA_SERVER_CERT))
@@ -306,7 +306,7 @@ instance_groups:
         ((#DB_EXTERNAL_HOST))((DB_EXTERNAL_DRIVER))((/DB_EXTERNAL_HOST))((^DB_EXTERNAL_HOST))mysql((/DB_EXTERNAL_HOST))
       properties.uaadb.port: &uaa-internal-database-port >
         ((#DB_EXTERNAL_HOST))((DB_EXTERNAL_PORT))((/DB_EXTERNAL_HOST))((^DB_EXTERNAL_HOST))3306((/DB_EXTERNAL_HOST))
-      properties.uaadb.roles: '[{"name": "uaaadmin", "password": "((UAADB_PASSWORD))", "tag": "admin"}]'
+      properties.uaadb.roles: '[{"name": "uaaadmin((DB_EXTERNAL_USER_HOST_SUFFIX))", "password": "((UAADB_PASSWORD))", "tag": "admin"}]'
       properties.uaadb.tls: "((UAADB_TLS))"
       properties.wait-for-database.hostname: *uaa-internal-database-host
       properties.wait-for-database.port: *uaa-internal-database-port
@@ -504,6 +504,13 @@ variables:
     description: >
       Administrator user name for an external database server; this is required
       to create the necessary databases.  Only used if DB_EXTERNAL_HOST is set.
+- name: DB_EXTERNAL_USER_HOST_SUFFIX
+  options:
+    immutable: true
+    description: >
+      A suffix that has to be appended to every user name for the external
+      database; usualy '@host'. Only used if DB_EXTERNAL_HOST is set.
+    default: ""
 - name: DOMAIN
   options:
     description: Base domain name of the UAA endpoint; `uaa.${DOMAIN}` must be correctly

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -306,14 +306,7 @@ instance_groups:
         ((#DB_EXTERNAL_HOST))((DB_EXTERNAL_DRIVER))((/DB_EXTERNAL_HOST))((^DB_EXTERNAL_HOST))mysql((/DB_EXTERNAL_HOST))
       properties.uaadb.port: &uaa-internal-database-port >
         ((#DB_EXTERNAL_HOST))((DB_EXTERNAL_PORT))((/DB_EXTERNAL_HOST))((^DB_EXTERNAL_HOST))3306((/DB_EXTERNAL_HOST))
-      properties.uaadb.roles: >
-        [
-          {
-            "name": "((#DB_EXTERNAL_HOST))((DB_EXTERNAL_USER))((/DB_EXTERNAL_HOST))((^DB_EXTERNAL_HOST))uaaadmin((/DB_EXTERNAL_HOST))",
-            "password": "((#DB_EXTERNAL_HOST))((DB_EXTERNAL_PASSWORD))((/DB_EXTERNAL_HOST))((^DB_EXTERNAL_HOST))((UAADB_PASSWORD))((/DB_EXTERNAL_HOST))",
-            "tag": "admin"
-          }
-        ]
+      properties.uaadb.roles: '[{"name": "uaaadmin", "password": "((UAADB_PASSWORD))", "tag": "admin"}]'
       properties.uaadb.tls: "((UAADB_TLS))"
       properties.wait-for-database.hostname: *uaa-internal-database-host
       properties.wait-for-database.port: *uaa-internal-database-port

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -314,6 +314,7 @@ instance_groups:
             "tag": "admin"
           }
         ]
+      properties.uaadb.tls: "((UAADB_TLS))"
       properties.wait-for-database.hostname: *uaa-internal-database-host
       properties.wait-for-database.port: *uaa-internal-database-port
 
@@ -711,6 +712,16 @@ variables:
     secret: true
     description: The password for access to the UAA database.
   type: password
+- name: UAADB_TLS
+  options:
+    description: |
+      Use TLS connection for UAA database.
+      Valid options are:
+      enabled (use TLS with full certificate validation),
+      enabled_skip_hostname_validation (use TLS but skip validation of common and alt names in the host certificate),
+      enabled_skip_all_validation (use TLS but do not validate anything about the host certificate),
+      disabled (do not use TLS)
+    default: enabled
 - name: UAA_ADMIN_CLIENT_SECRET
   options:
     secret: true

--- a/container-host-files/etc/scf/config/role-manifest.yml
+++ b/container-host-files/etc/scf/config/role-manifest.yml
@@ -509,7 +509,7 @@ variables:
     immutable: true
     description: >
       A suffix that has to be appended to every user name for the external
-      database; usualy '@host'. Only used if DB_EXTERNAL_HOST is set.
+      database; usually '@host'. Only used if DB_EXTERNAL_HOST is set.
     default: ""
 - name: DOMAIN
   options:


### PR DESCRIPTION
### Make `uaadb.tls` property configurable

So TLS can be disabled, or verification can be disabled when using an external database.

### Use `uaaadmin` username/password when talking to `uaadb`

The seeder credentials should only be used to create the `uaadb` database and `uaaadmin` user, but UAA itself should use the more limited creds.

### Add `DB_EXTERNAL_USER_HOST_SUFFIX` variable

On Azure MariaDB the username must always include the hostname, like `'user@host'@'host.azure.com`. This variable is appended to all hostnames in the rolemanifest.

Note that the cf-usb username is hardcoded in the release, so it will be incompatible with external database support on Azure.